### PR TITLE
Make build work again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,10 @@ jobs:
         repository: aequitas/AstroBuild
         path: astrobuild_repo
 
-    - name: Set up Python 3.9
+    - name: Set up Python 2.7
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '2.7'
 
     - name: Run astro_build.py
       run: python astrobuild_repo/astro_build.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,13 +14,10 @@ jobs:
         repository: aequitas/AstroBuild
         path: astrobuild_repo
 
-    - name: Install Python 2.7.18
-      shell: cmd
-      run: |
-        choco install wget --no-progress
-        wget -nv "https://www.python.org/ftp/python/2.7.18/python-2.7.18.amd64.msi"
-        start /wait msiexec.exe /passive /i python-2.7.18.amd64.msi /norestart /L*V "python_install.log" ADDLOCAL=ALL ALLUSERS=1 TARGETDIR=c:\python27
-        type "python_install.log"
+    - name: Set up Python 2.7
+      uses: LizardByte/setup-python-action@master
+      with:
+        python-version: '2.7'
 
     - name: Run astro_build.py
       run: python astrobuild_repo/astro_build.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,13 @@ jobs:
         repository: aequitas/AstroBuild
         path: astrobuild_repo
 
-    - name: Set up Python 2.7
-      uses: actions/setup-python@v4
-      with:
-        python-version: '2.7'
+    - name: Install Python 2.7.18
+      shell: cmd
+      run: |
+        choco install wget --no-progress
+        wget -nv "https://www.python.org/ftp/python/2.7.18/python-2.7.18.amd64.msi"
+        start /wait msiexec.exe /passive /i python-2.7.18.amd64.msi /norestart /L*V "python_install.log" ADDLOCAL=ALL ALLUSERS=1 TARGETDIR=c:\python27
+        type "python_install.log"
 
     - name: Run astro_build.py
       run: python astrobuild_repo/astro_build.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         sparse-checkout: .
-        repository: aequitas/AstroBuild
+        repository: FlorinPopaCodes/AstroBuild
         path: astrobuild_repo
 
     - name: Set up Python 2.7

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
     - name: Clone AstroBuild repository
-      run: |
-        git clone --depth=1 https://github.com/christian-s/AstroBuild.git astrobuild_repo
+      uses: actions/checkout@v4
+      with:
+        sparse-checkout: .
+        repository: aequitas/AstroBuild
+        path: astrobuild_repo
 
     - name: Set up Python 3.9
       uses: actions/setup-python@v4


### PR DESCRIPTION
After `christian-s/AstroBuild` was deleted, I had to make this build again.

I used the `christian-s` fork because it was upgraded to Python3. I couldn't use the original code because Github no longer supports 2.7. https://github.com/LizardByte/setup-python-action helped me make this transition smoothly.

I didn't think this needed too much effort for a gag.

I also created a fork of the original code, which I use to prevent further issues.

